### PR TITLE
moving to java25

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
@@ -58,10 +58,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/.github/workflows/sonatype-publish.yml
+++ b/.github/workflows/sonatype-publish.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Purpose
+This document guides automated agents and contributors making changes to this repository.
+
+## Non-Negotiable Rules
+- Do not introduce external dependencies without discussion.
+- Maintain Java 25+ compatibility.
+- Preserve API backward compatibility unless explicitly allowed.
+- All public APIs must include Javadoc.
+- All changes must include unit tests.
+
+## Architecture Constraints
+- Core data structures must remain allocation-efficient.
+- Avoid hidden object creation in hot paths.
+- APIs are designed for composition via input/output ports — do not collapse abstractions for convenience.
+- The library is by default intended to be single threaded. 
+- No reflection in core execution paths.
+
+## Coding Guidelines
+- Prefer immutability for public-facing objects.
+- Internal performance-sensitive paths may use mutable structures.
+- Avoid Streams API in hot paths; prefer loops.
+- Use primitive collections where possible to reduce boxing.
+
+## Testing Requirements
+- All new features must include:
+    - happy path tests
+    - edge cases (empty, null where applicable)
+    - concurrency tests if relevant
+
+## API Evolution
+- Do not remove or change existing public methods without:
+    - deprecation cycle
+    - migration notes
+- Prefer additive changes.
+- Avoid widening types in a way that breaks type inference.
+
+## Build & Validation
+- Build: `./gradlew build`
+- Run tests: `./gradlew test`
+- Format: `./gradlew spotlessApply`
+- CI must pass before merging.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
     `bytefacets-publishing-convention` apply false
     `bytefacets-central-portal-publishing-convention`
     id("pl.allegro.tech.build.axion-release") version "1.18.18" // https://plugins.gradle.org/plugin/pl.allegro.tech.build.axion-release
-    id("com.github.spotbugs") version "6.0.25"                  // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-gradle-plugin
-    id("com.diffplug.spotless") version "6.19.0"                 // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-plugin-gradle
+    id("com.github.spotbugs") version "6.4.12"                  // https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-gradle-plugin
+    id("com.diffplug.spotless") version "8.4.0"                 // https://mvnrepository.com/artifact/com.diffplug.spotless/spotless-plugin-gradle
 }
 gradle.startParameter.showStacktrace = ShowStacktrace.ALWAYS
 group = "com.bytefacets"
@@ -24,8 +24,8 @@ allprojects {
     java {
         withSourcesJar()
 
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 
     repositories {
@@ -62,18 +62,18 @@ subprojects {
     project.version = project.parent?.version!!
 
     extra.apply {
-        set("guavaVersion", "31.0.1-jre")
-        set("findbugsVersion", "4.7.3")
-        set("spotbugsVersion", "4.8.6")
+        set("guavaVersion", "33.5.0-jre")
+        set("findbugsVersion", "4.9.8")
+        set("spotbugsVersion", "4.9.4")
     }
 
     val spotbugsVersion: String by extra
     val findbugsVersion: String by extra
     val guavaVersion: String by extra
-    val junitVersion = "5.7.0"
+    val junitVersion = "5.11.4"
     val hamcrestVersion = "2.2"
     val mockitoVersion = "3.12.4"
-    val junitPioneerVersion = "0.9.0"
+    val junitPioneerVersion = "2.3.0"
 
     val mockitoAgent = configurations.create("mockitoAgent")
     dependencies {
@@ -122,7 +122,7 @@ subprojects {
     spotless {
         java {
             target("src/main/java/**/*.java", "src/test/java/**/*.java")
-            googleJavaFormat("1.25.2").aosp()
+            googleJavaFormat("1.35.0").aosp()
             indentWithSpaces()
             importOrder()
             removeUnusedImports()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,19 +9,19 @@ repositories {
 
 val jvmTargetVer = JavaLanguageVersion.of(17)
 
-java {
-    toolchain.languageVersion.set(jvmTargetVer)
-}
-
 kotlin {
-    jvmToolchain {
-        (this as JavaToolchainSpec).languageVersion.set(jvmTargetVer)
+    jvmToolchain(25)
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
+        // free compiler args
+        freeCompilerArgs.addAll(listOf("-Xjsr305=strict"))
     }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = "$jvmTargetVer"
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25)
+        freeCompilerArgs.addAll(listOf("-Xjsr305=strict"))
     }
 }
 

--- a/collections/src/main/java/com/bytefacets/collections/types/GenericType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/GenericType.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Objects;
 
 public final class GenericType {
@@ -24,9 +23,6 @@ public final class GenericType {
     public static final Cmp Desc = (a, b) -> nullableCompare(b, a);
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @SuppressFBWarnings(
-            value = "ES_COMPARING_PARAMETER_STRING_WITH_EQ",
-            justification = "this is a short-circuit for identity and null comparison")
     private static int nullableCompare(final Object a, final Object b) {
         if (a == b) {
             return 0;

--- a/collections/src/test/java/com/bytefacets/collections/types/BoolTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/BoolTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -77,7 +76,6 @@ class BoolTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/ByteTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/ByteTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -130,7 +129,6 @@ class ByteTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/DoubleTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/DoubleTypeTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -105,7 +104,6 @@ class DoubleTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/FloatTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/FloatTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -103,7 +102,6 @@ class FloatTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/IntTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/IntTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.LocalDate;
@@ -129,7 +128,6 @@ class IntTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/LongTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/LongTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -130,7 +129,6 @@ class LongTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/ShortTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/ShortTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -130,7 +129,6 @@ class ShortTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNumbers() {

--- a/collections/src/test/java/com/bytefacets/collections/types/StringTypeTest.java
+++ b/collections/src/test/java/com/bytefacets/collections/types/StringTypeTest.java
@@ -5,7 +5,6 @@ package com.bytefacets.collections.types;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -59,7 +58,6 @@ class StringTypeTest {
     }
 
     @Nested
-    @SuppressFBWarnings({"SIC_THREADLOCAL_DEADLY_EMBRACE", "SIC_INNER_SHOULD_BE_STATIC"})
     class ConvertTests {
         @Test
         void shouldConvertNullToDefaultValue() {

--- a/collections/src/test/templates/com/bytefacets/collections/arrays/KeyArrayTest.ftl
+++ b/collections/src/test/templates/com/bytefacets/collections/arrays/KeyArrayTest.ftl
@@ -9,7 +9,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.bytefacets.collections.types.${typeClass};
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,6 @@ class ${type.name}ArrayTest {
     }
 
     @Nested
-    @SuppressFBWarnings("SIC_THREADLOCAL_DEADLY_EMBRACE")
     class EnsureSizeTests {
         @Test
         void shouldGrowToEnsureSize() {
@@ -85,7 +83,6 @@ class ${type.name}ArrayTest {
     }
 
     @Nested
-    @SuppressFBWarnings("SIC_THREADLOCAL_DEADLY_EMBRACE")
     class EnsureEntryTests {
         @Test
         void shouldGrowToEnsureEntry() {

--- a/examples/src/main/java/com/bytefacets/collections/bi/InvertedIndexExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/bi/InvertedIndexExample.java
@@ -28,7 +28,7 @@ final class InvertedIndexExample {
         System.out.println();
     }
 
-    private static class InvertedIndex {
+    private static final class InvertedIndex {
         // range transformation for orders ids which are longs
         private final LongIndexedSet orders = new LongIndexedSet(128);
         // range transformation for terms

--- a/examples/src/main/java/com/bytefacets/collections/bi/ManyToManyExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/bi/ManyToManyExample.java
@@ -64,7 +64,7 @@ final class ManyToManyExample {
         school.updateClass("Civics", "Mrs. Carlson");
     }
 
-    private static class School {
+    private static final class School {
         private final StringIndexedSet students = new StringIndexedSet(16);
         private final StringStringIndexedMap classToTeacher = new StringStringIndexedMap(16);
         private final CompactManyToMany registrations = new CompactManyToMany();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
moving to java25, mainly for off-heap memory functionality
- necessary updates to some build dependencies
- tweaks to spotbugs and checkstyle suppressions due to fixes for false positives or other minor things