### PR TITLE
large stores using off-heap memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ That they are primitive based is an obvious benefit over the standard JDK collec
 main advantages here are around memory:
 - primitive types use less memory than Objects
 - using fewer Objects reduces work for the garbage collector
+- better cache locality when members of the collection
 
 For example, a typical set like the IntIndexedSet, which is very much like a hash set uses
 only 5 objects (3 int[], a hash function reference, and a equality function reference).
@@ -18,6 +19,10 @@ only 5 objects (3 int[], a hash function reference, and a equality function refe
 The *IndexedSet collections are hash-table-based, so perform slightly worse than the FastUtil 
 primitive collections which use open hashing. The trade-off is the stability of where
 the key resides during resizing operations, an important aspect of the next feature. 
+
+Note that you won't see the collections' Java implementations in the repository because they
+are generated using FreeMarker [templates](collections/src/main/templates/com/bytefacets/collections/) 
+as are their [tests](collections/src/test/templates/com/bytefacets/collections). 
 
 ### Indexed-Enabled
 Several of the collections in the library produce an "entry" when an element is added to them.
@@ -43,7 +48,6 @@ The heap implementation is map-like so that you can associate a value with the o
 Another difference with the JDK PriorityQueue is that with the ByteFacets Heap, you can store
 an element's entry in the heap for direct access.
 
-
 #### CompactOneToMany, CompactManyToMany
 These collections offer relationship mapping and navigability. "Compact" here means that the 
 collection is most efficient when left and right entries are 0-based integers due their use of 
@@ -52,8 +56,8 @@ the set and map collections to provide a mechanism to track relationships betwee
 collections.
 
 #### Store, MatrixStore
-The stores provide a simple index-based abstraction for storing values, in this case arrays, but 
-in could be off-heap memory, via new jdk-21 features or through something like Apache Arrow. 
+The stores provide a simple index-based abstraction for storing values, either in arrays in heap memory,
+or in off-heap memory, via jdk-25 features, or you could store in something like Apache Arrow. 
 *Store types handle growing to accommodate new indecies. If Chunked, the store will also grow 
 efficiently by extending the storage in blocks, reusing existing blocks in the new structure. 
 

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -11,9 +11,22 @@ template_processor {
             "BoolIndexedCollection.java",
             "BaseBoolHeap.java",
             "BaseBoolIndex.java",
-            "BoolIndexedSet.java"))
+            "BoolIndexedSet.java",
+            "LargeStringStore.java",
+            "LargeGenericStore.java",
+            "LargeStringMatrixStore.java",
+            "LargeGenericMatrixStore.java",
+            "LargeStringChunkMatrixStore.java",
+            "LargeGenericChunkMatrixStore.java",
+            "LargeStringChunkStore.java",
+            "LargeGenericChunkStore.java"))
     }
     test {
-        excludedFiles.set(listOf("BoolIndexedSetTest.java"))
+        excludedFiles.set(listOf(
+            "BoolIndexedSetTest.java",
+            "LargeStringChunkMatrixStoreTest.java",
+            "LargeGenericChunkMatrixStoreTest.java",
+            "LargeStringChunkStoreTest.java",
+            "LargeGenericChunkStoreTest.java"))
     }
 }

--- a/collections/build.gradle.kts
+++ b/collections/build.gradle.kts
@@ -5,6 +5,19 @@ plugins {
 
 apply(plugin = "com.bytefacets.template_processor")
 
+tasks.test {
+    useJUnitPlatform {
+        excludeTags("large")
+    }
+}
+
+tasks.register<Test>("largeTests") {
+    useJUnitPlatform {
+        includeTags("large")
+    }
+    maxParallelForks = 1
+}
+
 template_processor {
     main {
         excludedFiles.set(listOf(

--- a/collections/src/main/java/com/bytefacets/collections/exception/InitializationException.java
+++ b/collections/src/main/java/com/bytefacets/collections/exception/InitializationException.java
@@ -13,4 +13,11 @@ public final class InitializationException extends RuntimeException {
                     String.format("%s must be >= %d, but was %d", field, minValid, value));
         }
     }
+
+    public static void assertMinimum(final long minValid, final long value, final String field) {
+        if (value < minValid) {
+            throw new InitializationException(
+                    String.format("%s must be >= %d, but was %d", field, minValid, value));
+        }
+    }
 }

--- a/collections/src/main/java/com/bytefacets/collections/types/BoolType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/BoolType.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class BoolType {
     public static final boolean DEFAULT = false;
+    public static final ValueLayout.OfBoolean VALUE_LAYOUT = ValueLayout.JAVA_BOOLEAN;
 
     private BoolType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/ByteType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/ByteType.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class ByteType {
     public static final byte DEFAULT = 0;
+    public static final ValueLayout.OfByte VALUE_LAYOUT = ValueLayout.JAVA_BYTE;
 
     private ByteType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/CharType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/CharType.java
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class CharType {
     public static final char DEFAULT = 0;
     public static final char TRUE = 't';
     public static final char FALSE = 'f';
+    public static final ValueLayout.OfChar VALUE_LAYOUT = ValueLayout.JAVA_CHAR;
 
     private CharType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/DoubleType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/DoubleType.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class DoubleType {
     public static final double DEFAULT = 0;
+    public static final ValueLayout.OfDouble VALUE_LAYOUT = ValueLayout.JAVA_DOUBLE;
 
     private DoubleType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/FloatType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/FloatType.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class FloatType {
     public static final float DEFAULT = 0;
+    public static final ValueLayout.OfFloat VALUE_LAYOUT = ValueLayout.JAVA_FLOAT;
 
     private FloatType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/IntType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/IntType.java
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Date;
 
 public final class IntType {
     public static final int DEFAULT = 0;
+    public static final ValueLayout.OfInt VALUE_LAYOUT = ValueLayout.JAVA_INT;
 
     private IntType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/LongType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/LongType.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class LongType {
     public static final long DEFAULT = 0;
+    public static final ValueLayout.OfLong VALUE_LAYOUT = ValueLayout.JAVA_LONG;
 
     private LongType() {}
 

--- a/collections/src/main/java/com/bytefacets/collections/types/ShortType.java
+++ b/collections/src/main/java/com/bytefacets/collections/types/ShortType.java
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 package com.bytefacets.collections.types;
 
+import java.lang.foreign.ValueLayout;
+
 public final class ShortType {
     public static final short DEFAULT = 0;
+    public static final ValueLayout.OfShort VALUE_LAYOUT = ValueLayout.JAVA_SHORT;
 
     private ShortType() {}
 

--- a/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStore.ftl
+++ b/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStore.ftl
@@ -16,9 +16,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * A matrix store for ${type.javaType} values which are stored in array "chunks". Using chunks is
- * especially beneficial for resizing because only new chunks need to be allocated and the
- * copying is at the chunk level.
+ * A matrix store for ${type.javaType} values which are stored in MemorySegment "chunks". Using chunks is
+ * especially beneficial for resizing because only new chunks need to be allocated.
  */
 public final class Large${type.name}ChunkMatrixStore${generics} implements Large${type.name}MatrixStore${generics} {
     private final Arena arena;

--- a/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStore.ftl
+++ b/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStore.ftl
@@ -1,0 +1,134 @@
+<#ftl strip_whitespace=true>
+// SPDX-FileCopyrightText: Copyright (c) 2025 Byte Facets
+// SPDX-License-Identifier: MIT
+package com.bytefacets.collections.store;
+
+import com.bytefacets.collections.NumUtils;
+import com.bytefacets.collections.exception.InitializationException;
+import com.bytefacets.collections.exception.RangeCheckException;
+import com.bytefacets.collections.types.${type.name}Type;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A matrix store for ${type.javaType} values which are stored in array "chunks". Using chunks is
+ * especially beneficial for resizing because only new chunks need to be allocated and the
+ * copying is at the chunk level.
+ */
+public final class Large${type.name}ChunkMatrixStore${generics} implements Large${type.name}MatrixStore${generics} {
+    private final Arena arena;
+    private final int chunkSize;
+    private final int chunkMask;
+    private final int shift;
+    private final int numFields;
+    private final List<MemorySegment> chunks;
+    /** The current full row capacity of the store. */
+    private long capacity;
+    private boolean closed;
+
+    /**
+     * @param initialSize the initial size of the store in terms of the number of groups of fields;
+                          though depending on the chunkSize, you may see your initialSize larger
+                          than requested; minimum valid value is 1
+     * @param chunkSize   the size of the arrays used internally which impact data locality and growth.
+     *                    minimum value is 2, and given values will be rounded up to the next power of 2
+     * @param numFields   the number of logical fields in the store; minimum valid value is 1
+     */
+    public Large${type.name}ChunkMatrixStore(final long initialSize, final int chunkSize, final int numFields) {
+        InitializationException.assertMinimum(1, initialSize, "initialSize");
+        InitializationException.assertMinimum(2, chunkSize, "chunkSize");
+        InitializationException.assertMinimum(1, numFields, "numFields");
+
+        this.arena = Arena.ofConfined();
+        this.chunkSize = NumUtils.nextPowerOf2(chunkSize);
+        this.chunkMask = chunkSize - 1;
+        this.shift = Long.numberOfTrailingZeros(this.chunkSize);
+        this.numFields = numFields;
+        final long rawSize = initialSize * numFields;
+        final int requiredChunks = (int) Math.ceil((double)rawSize / (double)this.chunkSize);
+        this.chunks = new ArrayList<>(requiredChunks);
+        grow(initialSize);
+    }
+
+    /** Releases allocated memory. */
+    @Override
+    public void close() {
+        if(closed) {
+            throw new IllegalStateException("Store is already closed.");
+        }
+        closed = true;
+        arena.close();
+    }
+
+    /**
+     * Returns the value at the given row and field. If the row is beyond the capacity
+     * of the store, it will return the ${type.javaType} default value. The field should be
+     * within the numFields that the store was instantiated with.
+     *
+     * @throws IndexOutOfBoundsException if the row is negative or if the calculated array
+     *              index is beyond the bounds.
+     * @throws com.bytefacets.collections.exception.RangeCheckException if the field is not within [0, numFields]
+     */
+    <#if type.generic>@SuppressWarnings("unchecked")</#if>
+    @Override
+    public ${type.javaType} get${type.name}(final long row, final int field) {
+        assertNotClosed();
+        RangeCheckException.assertWithinRange(0, numFields - 1, field, "field");
+        if(row >= capacity) {
+            return ${type.cast}${type.name}Type.DEFAULT;
+        }
+        final long absoluteIx = (row * numFields) + field;
+        final int offset = (int)(absoluteIx & chunkMask);
+        final int chunk = (int)(absoluteIx >> shift);
+        final MemorySegment segment = chunks.get(chunk);
+        return segment.getAtIndex(${type.name}Type.VALUE_LAYOUT, offset);
+    }
+
+    /**
+     * Sets the value at the given row and field, growing the store if necessary.
+     *
+     * @throws com.bytefacets.collections.exception.RangeCheckException if the field is not within [0, numFields)
+     */
+    @Override
+    public void set${type.name}(final long row, final int field, final ${type.javaType} value) {
+        assertNotClosed();
+        RangeCheckException.assertWithinRange(0, numFields - 1, field, "field");
+        if(row >= capacity) {
+            grow(row+1);
+        }
+        final long absoluteIx = (row * numFields) + field;
+        final int offset = (int)(absoluteIx & chunkMask);
+        final int chunk = (int)(absoluteIx >>> shift);
+        final MemorySegment segment = chunks.get(chunk);
+        segment.setAtIndex(${type.name}Type.VALUE_LAYOUT, offset, value);
+    }
+
+    /** The current full row capacity of the store. */
+    public long getCapacity() {
+        return capacity;
+    }
+
+    // VisibleForTesting
+    int numChunks() {
+        return chunks.size();
+    }
+
+    private void grow(final long row) {
+        final long rawSize = row * numFields;
+        final int requiredChunks = (int) Math.ceil((double)rawSize / (double)chunkSize);
+        final int oldLen = chunks.size();
+        for(int i = oldLen; i < requiredChunks; i++) {
+            chunks.add(arena.allocate(${type.name}Type.VALUE_LAYOUT, chunkSize));
+        }
+        this.capacity = (chunks.size() * ((long)chunkSize)) / numFields;
+    }
+
+    private void assertNotClosed() {
+        if(closed) throw new IllegalStateException("Store is closed");
+    }
+}

--- a/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkStore.ftl
+++ b/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkStore.ftl
@@ -13,9 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A store for ${type.javaType} values which are stored in array "chunks". Using chunks is
- * especially beneficial for resizing because only new chunks need to be allocated and the
- * copying is at the chunk level.
+ * A store for ${type.javaType} values which are stored in MemorySegment "chunks". Using chunks is
+ * especially beneficial for resizing because only new chunks need to be allocated.
  */
 public final class Large${type.name}ChunkStore${generics} implements Large${type.name}Store${generics} {
     private final Arena arena;

--- a/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkStore.ftl
+++ b/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyChunkStore.ftl
@@ -1,0 +1,109 @@
+<#ftl strip_whitespace=true>
+// SPDX-FileCopyrightText: Copyright (c) 2025 Byte Facets
+// SPDX-License-Identifier: MIT
+package com.bytefacets.collections.store;
+
+import com.bytefacets.collections.exception.InitializationException;
+import com.bytefacets.collections.NumUtils;
+import com.bytefacets.collections.types.${type.name}Type;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A store for ${type.javaType} values which are stored in array "chunks". Using chunks is
+ * especially beneficial for resizing because only new chunks need to be allocated and the
+ * copying is at the chunk level.
+ */
+public final class Large${type.name}ChunkStore${generics} implements Large${type.name}Store${generics} {
+    private final Arena arena;
+    private final int chunkSize;
+    private final int chunkMask;
+    private final int shift;
+    private final List<MemorySegment> chunks;
+    private long capacity;
+    private long limit;
+    private boolean closed;
+
+    public Large${type.name}ChunkStore(final long initialSize, final int chunkSize) {
+        InitializationException.assertMinimum(1, initialSize, "initialSize");
+        InitializationException.assertMinimum(2, chunkSize, "chunkSize");
+
+        this.arena = Arena.ofConfined();
+        this.chunkSize = NumUtils.nextPowerOf2(chunkSize);
+        this.chunkMask = chunkSize - 1;
+        this.shift = Long.numberOfTrailingZeros(this.chunkSize);
+        final int requiredChunks = (int) Math.ceil((double)initialSize / (double)this.chunkSize);
+        this.chunks = new ArrayList<>(requiredChunks);
+        grow(initialSize);
+    }
+
+    /** Releases allocated memory. */
+    @Override
+    public void close() {
+        if(closed) {
+            throw new IllegalStateException("Store is closed.");
+        }
+        closed = true;
+        capacity = -1;
+        limit = -1;
+        chunks.clear();
+        arena.close();
+    }
+
+    /** Returns the value at the given index. */
+    <#if type.generic>@SuppressWarnings("unchecked")</#if>
+    @Override
+    public ${type.javaType} get${type.name}(final long index) {
+        assertNotClosed();
+        if(index >= capacity) {
+            return <#if type.generic>(T)</#if>${type.name}Type.DEFAULT;
+        }
+        final int offset = (int)(index & chunkMask);
+        final int chunk = (int)(index >>> shift);
+        final MemorySegment segment = chunks.get(chunk);
+        return segment.getAtIndex(${type.name}Type.VALUE_LAYOUT, offset);
+    }
+
+    /**
+     * Sets the value at the given index, and grows the store to accommodate the index
+     * if necessary.
+     */
+    @Override
+    public void set${type.name}(final long index, final ${type.javaType} value) {
+        assertNotClosed();
+        if(index >= capacity) {
+            grow(index+1);
+        }
+        limit = Math.max(limit, index);
+        final int offset = (int)(index & chunkMask);
+        final int chunk = (int)(index >> shift);
+        final MemorySegment segment = chunks.get(chunk);
+        segment.setAtIndex(${type.name}Type.VALUE_LAYOUT, offset, value);
+    }
+
+    /** The current capacity of this store. */
+    public long getCapacity() {
+        return capacity;
+    }
+
+    // VisibleForTesting
+    int numChunks() {
+        return chunks.size();
+    }
+
+    private void grow(final long index) {
+        final int requiredChunks = (int) Math.ceil((double)index / (double)this.chunkSize);
+        final int oldLen = chunks.size();
+        for(int i = oldLen; i < requiredChunks; i++) {
+            chunks.add(arena.allocate(${type.name}Type.VALUE_LAYOUT, chunkSize));
+        }
+        this.capacity = chunks.size() * ((long)this.chunkSize);
+    }
+
+    private void assertNotClosed() {
+        if(closed) throw new IllegalStateException("Store is closed");
+    }
+}

--- a/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyMatrixStore.ftl
+++ b/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyMatrixStore.ftl
@@ -1,0 +1,16 @@
+<#ftl strip_whitespace=true>
+// SPDX-FileCopyrightText: Copyright (c) 2025 Byte Facets
+// SPDX-License-Identifier: MIT
+package com.bytefacets.collections.store;
+
+/** A store that allows for multiple fields of the same type at each row. */
+public interface Large${type.name}MatrixStore${generics} extends AutoCloseable {
+    /** Returns the value at the given row and field. */
+    ${type.javaType} get${type.name}(long row, int field);
+
+    /** Sets the value at the given row and field. */
+    void set${type.name}(long row, int field, ${type.javaType} value);
+
+    /** Releases the memory for the store. */
+    void close();
+}

--- a/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyStore.ftl
+++ b/collections/src/main/templates/com/bytefacets/collections/store/LargeKeyStore.ftl
@@ -1,0 +1,16 @@
+<#ftl strip_whitespace=true>
+// SPDX-FileCopyrightText: Copyright (c) 2025 Byte Facets
+// SPDX-License-Identifier: MIT
+package com.bytefacets.collections.store;
+
+/** A store of ${type.javaType}. */
+public interface Large${type.name}Store${generics} extends AutoCloseable {
+    /** Returns the value at the given index. */
+    ${type.javaType} get${type.name}(long index);
+
+    /** Sets the value at the given index. */
+    void set${type.name}(long index, ${type.javaType} value);
+
+    /** Releases the memory for the store. */
+    void close();
+}

--- a/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStoreTest.ftl
+++ b/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStoreTest.ftl
@@ -13,10 +13,12 @@ import com.bytefacets.collections.exception.RangeCheckException;
 
 <#if !type.generic>import com.bytefacets.collections.types.${typeClass};</#if>
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+@Tag("large")
 class Large${type.name}ChunkMatrixStoreTest {
     private static final int CHUNK_SIZE = 16;
     private static final int NUM_FIELDS = 3;

--- a/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStoreTest.ftl
+++ b/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkMatrixStoreTest.ftl
@@ -1,0 +1,95 @@
+<#ftl strip_whitespace=true>
+// SPDX-FileCopyrightText: Copyright (c) 2025 Byte Facets
+// SPDX-License-Identifier: MIT
+<#assign typeClass = "${type.name}Type">
+<#assign arrayClass = "${type.name}Array">
+package com.bytefacets.collections.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
+
+import com.bytefacets.collections.exception.RangeCheckException;
+
+<#if !type.generic>import com.bytefacets.collections.types.${typeClass};</#if>
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class Large${type.name}ChunkMatrixStoreTest {
+    private static final int CHUNK_SIZE = 16;
+    private static final int NUM_FIELDS = 3;
+<#if type.generic>
+    private final Large${type.name}ChunkMatrixStore<String> store = new Large${type.name}ChunkMatrixStore<>(5, CHUNK_SIZE, NUM_FIELDS);
+    private void set(final long index, final int field, final String value) {
+        store.set${type.name}(index, field, value);
+    }
+
+    private String get(final long index, final int field) {
+        return store.get${type.name}(index, field);
+    }
+
+    private String convert(final String value) {
+        return value;
+    }
+<#else>
+    private final Large${type.name}ChunkMatrixStore store = new Large${type.name}ChunkMatrixStore(5, CHUNK_SIZE, NUM_FIELDS);
+    private void set(final long index, final int field, final ${type.javaType} value) {
+        store.set${type.name}(index, field, value);
+    }
+
+    private ${type.javaType} get(final long index, final int field) {
+        return store.get${type.name}(index, field);
+    }
+
+    private ${type.javaType} convert(final String value) {
+        return ${typeClass}.parseString(value);
+    }
+</#if>
+
+    @AfterEach
+    void releaseMemory() {
+        store.close();
+    }
+
+    @Test
+    void shouldRoundTripValues() {
+        set(3, 1, convert("7"));
+        set(2, 2, convert("8"));
+        set(1, 0, convert("9"));
+        assertThat(get(3, 1), equalTo(convert("7")));
+        assertThat(get(2, 2), equalTo(convert("8")));
+        assertThat(get(1, 0), equalTo(convert("9")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"6,2,10", "11,3,16", "42,9,48"})
+    void shouldGrowToAccommodateNewIndex(final long index, final int expectedChunks, final int expectedCapacity) {
+        set(index, 2, convert("7"));
+        assertThat(store.getCapacity(), equalTo(((long)expectedCapacity)));
+        assertThat(store.numChunks(), equalTo(expectedChunks));
+        assertThat(get(index, 2), equalTo(convert("7")));
+    }
+
+    @Test
+    void shouldThrowWhenRequestingNegativeField() {
+        assertThrows(RangeCheckException.class, () -> get(1, -1));
+        assertThrows(RangeCheckException.class, () -> set(1, -1, convert("7")));
+    }
+
+    @Test
+    void shouldThrowWhenRequestingFieldLargerThanConfigured() {
+        assertThrows(RangeCheckException.class, () -> get(1, NUM_FIELDS));
+        assertThrows(RangeCheckException.class, () -> set(1, NUM_FIELDS, convert("7")));
+    }
+
+    @Test
+    void shouldGrowWhenLarge() {
+        try(Large${type.name}ChunkStore largeStore = new Large${type.name}ChunkStore(Integer.MAX_VALUE, Integer.MAX_VALUE/512)) {
+            long index = ((long)Integer.MAX_VALUE) + 1L;
+            largeStore.set${type.name}(index, convert("7"));
+            assertThat(largeStore.get${type.name}(index), equalTo(convert("7")));
+        }
+    }
+}

--- a/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkStoreTest.ftl
+++ b/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkStoreTest.ftl
@@ -1,0 +1,83 @@
+<#ftl strip_whitespace=true>
+// SPDX-FileCopyrightText: Copyright (c) 2025 Byte Facets
+// SPDX-License-Identifier: MIT
+<#assign typeClass = "${type.name}Type">
+<#assign arrayClass = "${type.name}Array">
+package com.bytefacets.collections.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+<#if !type.generic>import com.bytefacets.collections.types.${typeClass};</#if>
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class Large${type.name}ChunkStoreTest {
+<#if type.generic>
+    private final Large${type.name}ChunkStore<String> store = new Large${type.name}ChunkStore<>(5, 4);
+    private void set(final long index, final String value) {
+        store.set${type.name}(index, value);
+    }
+
+    private String get(final long index) {
+        return store.get${type.name}(index);
+    }
+
+    private String convert(final String value) {
+        return value;
+    }
+<#else>
+    private final Large${type.name}ChunkStore store = new Large${type.name}ChunkStore(5, 3);
+    private void set(final long index, final ${type.javaType} value) {
+        store.set${type.name}(index, value);
+    }
+
+    private ${type.javaType} get(final long index) {
+        return store.get${type.name}(index);
+    }
+
+    private ${type.javaType} convert(final String value) {
+        return ${typeClass}.parseString(value);
+    }
+</#if>
+
+    @AfterEach
+    void releaseMemory() {
+        store.close();
+    }
+
+    @Test
+    void shouldRoundTripValue() {
+        final var value = convert("7");
+        set(3, value);
+        assertThat(get(3), equalTo(value));
+    }
+
+    @Test
+    void shouldGrowAtCapacity() {
+        final var value = convert("7");
+        final long index = store.getCapacity();
+        set(index, value);
+        assertThat(get(index), equalTo(value));
+    }
+
+    @Test
+    void shouldGrowWhenLarge() {
+        try(Large${type.name}ChunkStore largeStore = new Large${type.name}ChunkStore(Integer.MAX_VALUE, Integer.MAX_VALUE/512)) {
+            long index = ((long)Integer.MAX_VALUE) + 1L;
+            largeStore.set${type.name}(index, convert("7"));
+            assertThat(largeStore.get${type.name}(index), equalTo(convert("7")));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"6,8","11,12","41,44"})
+    void shouldGrowToAccommodateNewIndex(final long index, final long expectedCapacity) {
+        set(index, convert("7"));
+        assertThat(store.numChunks(), equalTo((int)(expectedCapacity/4)));
+        assertThat(store.getCapacity(), equalTo(expectedCapacity));
+        assertThat(get(index), equalTo(convert("7")));
+    }
+}

--- a/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkStoreTest.ftl
+++ b/collections/src/test/templates/com/bytefacets/collections/store/LargeKeyChunkStoreTest.ftl
@@ -10,10 +10,12 @@ import static org.hamcrest.Matchers.equalTo;
 
 <#if !type.generic>import com.bytefacets.collections.types.${typeClass};</#if>
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+@Tag("large")
 class Large${type.name}ChunkStoreTest {
 <#if type.generic>
     private final Large${type.name}ChunkStore<String> store = new Large${type.name}ChunkStore<>(5, 4);

--- a/examples/src/main/java/com/bytefacets/collections/bi/InvertedIndexExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/bi/InvertedIndexExample.java
@@ -6,7 +6,43 @@ import com.bytefacets.collections.functional.LongConsumer;
 import com.bytefacets.collections.hash.LongIndexedSet;
 import com.bytefacets.collections.hash.StringIndexedSet;
 
-/** This is a small example using the CompactOneToMany to implement a small inverted index. */
+/**
+ * This is a small example using the CompactOneToMany to implement a small inverted index.
+ * <p/>
+ * Example output:<p/>
+ * <pre>
+ * Adding 1000000: symbol=YHOO, strategy=TWAP
+ * Adding 1000001: symbol=CSCO, strategy=VWAP
+ * Adding 1000002: symbol=MSFT, strategy=POV
+ * Adding 1000003: symbol=AAPL, strategy=TWAP
+ * Adding 1000004: symbol=YHOO, strategy=VWAP
+ * Adding 1000005: symbol=CSCO, strategy=POV
+ * Adding 1000006: symbol=MSFT, strategy=TWAP
+ * Adding 1000007: symbol=AAPL, strategy=VWAP
+ * Adding 1000008: symbol=YHOO, strategy=POV
+ * Adding 1000009: symbol=CSCO, strategy=TWAP
+ * Adding 1000010: symbol=MSFT, strategy=VWAP
+ * Adding 1000011: symbol=AAPL, strategy=POV
+ * Adding 1000012: symbol=YHOO, strategy=TWAP
+ * Adding 1000013: symbol=CSCO, strategy=VWAP
+ * Adding 1000014: symbol=MSFT, strategy=POV
+ * Adding 1000015: symbol=AAPL, strategy=TWAP
+ * Adding 1000016: symbol=YHOO, strategy=VWAP
+ * Adding 1000017: symbol=CSCO, strategy=POV
+ * Adding 1000018: symbol=MSFT, strategy=TWAP
+ * Adding 1000019: symbol=AAPL, strategy=VWAP
+ * Adding 1000020: symbol=YHOO, strategy=POV
+ * Adding 1000021: symbol=CSCO, strategy=TWAP
+ * Adding 1000022: symbol=MSFT, strategy=VWAP
+ * Adding 1000023: symbol=AAPL, strategy=POV
+ * Adding 1000024: symbol=YHOO, strategy=TWAP
+ * Adding 1000025: symbol=CSCO, strategy=VWAP
+ * Adding 1000026: symbol=MSFT, strategy=POV
+ * MSFT (7):1000026 1000022 1000018 1000014 1000010 1000006 1000002
+ * XFOO (0):
+ * VWAP (9):1000025 1000022 1000019 1000016 1000013 1000010 1000007 1000004 1000001
+ * </pre>
+ */
 final class InvertedIndexExample {
     private InvertedIndexExample() {}
 
@@ -29,9 +65,9 @@ final class InvertedIndexExample {
     }
 
     private static final class InvertedIndex {
-        // range transformation for orders ids which are longs
+        // range transformation for orders ids which are longs, turning them into compact ints
         private final LongIndexedSet orders = new LongIndexedSet(128);
-        // range transformation for terms
+        // range transformation for terms, turning them into compact ints
         private final StringIndexedSet terms = new StringIndexedSet(128);
         // the index associating the term with the order entry
         private final CompactOneToMany index = new CompactOneToMany(128, 128, true);

--- a/examples/src/main/java/com/bytefacets/collections/bi/InvertedIndexExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/bi/InvertedIndexExample.java
@@ -8,8 +8,11 @@ import com.bytefacets.collections.hash.StringIndexedSet;
 
 /**
  * This is a small example using the CompactOneToMany to implement a small inverted index.
- * <p/>
- * Example output:<p/>
+ *
+ * <p>Example output:
+ *
+ * <p>
+ *
  * <pre>
  * Adding 1000000: symbol=YHOO, strategy=TWAP
  * Adding 1000001: symbol=CSCO, strategy=VWAP

--- a/examples/src/main/java/com/bytefacets/collections/bi/ManyToManyExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/bi/ManyToManyExample.java
@@ -13,6 +13,61 @@ import java.util.stream.Stream;
  * This is a small example using the CompactManyToMany to record class-to-student relationships.
  * Classes have many students, and students have many classes, and we can navigate either side of
  * the relationship.
+ * <p/>
+ * Example output:<p/>
+ * <pre>
+ * English taught by Mr. Fletcher
+ * Science taught by Mrs. White
+ * Latin taught by Mr. Wilson
+ * Math taught by Mr. Cooper
+ * History taught by Mrs. Barber
+ * Civics taught by Mrs. Carlson
+ * Enrolling Sujith Kalra in Science
+ * Enrolling Sujith Kalra in History
+ * Enrolling Jose Garcia in English
+ * Enrolling Jose Garcia in Math
+ * Enrolling Suneeta Kumar in Science
+ * Enrolling Suneeta Kumar in History
+ * Enrolling Igor Chekov in English
+ * Enrolling Igor Chekov in Science
+ * Enrolling Sasha Petrovich in Science
+ * Enrolling Sasha Petrovich in Math
+ * Enrolling Alex Pedersen in English
+ * Enrolling Alex Pedersen in Civics
+ * Enrolling Rachel Schwartz in Latin
+ * Enrolling Rachel Schwartz in History
+ * Enrolling Luke Jorgens in History
+ * Enrolling Luke Jorgens in Civics
+ * Enrolling Jennifer O'Brian in Science
+ * Enrolling Jennifer O'Brian in Latin
+ * Enrolling Mary Johnson in Math
+ * Enrolling Mary Johnson in Civics
+ * Civics (3) taught by Mrs. Carlson:
+ *    Mary Johnson
+ *    Luke Jorgens
+ *    Alex Pedersen
+ *
+ * History (4) taught by Mrs. Barber:
+ *    Luke Jorgens
+ *    Rachel Schwartz
+ *    Suneeta Kumar
+ *    Sujith Kalra
+ *
+ * Changing teachers.... History taught by Mr. Parker
+ * History (4) taught by Mr. Parker:
+ *    Luke Jorgens
+ *    Rachel Schwartz
+ *    Suneeta Kumar
+ *    Sujith Kalra
+ *
+ * Suneeta Kumar (2):
+ *    History taught by Mr. Parker
+ *    Science taught by Mrs. White
+ *
+ * Luke Jorgens (2):
+ *    Civics taught by Mrs. Carlson
+ *    History taught by Mr. Parker
+ * </pre>
  */
 final class ManyToManyExample {
     private static final String[] CLASSES =

--- a/examples/src/main/java/com/bytefacets/collections/bi/ManyToManyExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/bi/ManyToManyExample.java
@@ -13,8 +13,11 @@ import java.util.stream.Stream;
  * This is a small example using the CompactManyToMany to record class-to-student relationships.
  * Classes have many students, and students have many classes, and we can navigate either side of
  * the relationship.
- * <p/>
- * Example output:<p/>
+ *
+ * <p>Example output:
+ *
+ * <p>
+ *
  * <pre>
  * English taught by Mr. Fletcher
  * Science taught by Mrs. White

--- a/examples/src/main/java/com/bytefacets/collections/heap/TimeoutExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/heap/TimeoutExample.java
@@ -13,8 +13,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <p>The example uses standard JDK threading to coordinate the arrival, acknowledgement, and
  * timeouts.
- * <p/>
- * Example output:<p/>
+ *
+ * <p>Example output:
+ *
+ * <p>
+ *
  * <pre>
  * registering 0 expecting to timeout at 1777385240032
  * acknowledged: 40
@@ -59,7 +62,7 @@ final class TimeoutExample {
         // something that will register new items
         final ItemArrival itemArrival = new ItemArrival(manager, acknowledger);
 
-        try(var pool = Executors.newScheduledThreadPool(2)) {
+        try (var pool = Executors.newScheduledThreadPool(2)) {
             // push new items into the "system"
             pool.scheduleAtFixedRate(itemArrival::newItemArrived, 1, 10, TimeUnit.MILLISECONDS);
             // acknowledge the items we decided

--- a/examples/src/main/java/com/bytefacets/collections/heap/TimeoutExample.java
+++ b/examples/src/main/java/com/bytefacets/collections/heap/TimeoutExample.java
@@ -13,6 +13,30 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * <p>The example uses standard JDK threading to coordinate the arrival, acknowledgement, and
  * timeouts.
+ * <p/>
+ * Example output:<p/>
+ * <pre>
+ * registering 0 expecting to timeout at 1777385240032
+ * acknowledged: 40
+ * registering 50 expecting to timeout at 1777385240532
+ * acknowledged: 50
+ * acknowledged: 80
+ * registering 100 expecting to timeout at 1777385241032
+ * acknowledged: 120
+ * registering 150 expecting to timeout at 1777385241532
+ * 1777385240033 timeout observed for item 0, 1ms past due
+ * acknowledged: 170
+ * registering 200 expecting to timeout at 1777385242033
+ * 1777385240533 timeout observed for item 50, 1ms past due
+ * acknowledged: 210
+ * acknowledged: 240
+ * registering 250 expecting to timeout at 1777385242533
+ * acknowledged: 250
+ * 1777385241033 timeout observed for item 100, 1ms past due
+ * acknowledged: 280
+ * registering 300 expecting to timeout at 1777385243032
+ * 1777385241533 timeout observed for item 150, 1ms past due
+ * </pre>
  */
 final class TimeoutExample {
     private static final long DEFAULT_WAIT_MS = 100;
@@ -35,14 +59,15 @@ final class TimeoutExample {
         // something that will register new items
         final ItemArrival itemArrival = new ItemArrival(manager, acknowledger);
 
-        final var pool = Executors.newScheduledThreadPool(2);
-        // push new items into the "system"
-        pool.scheduleAtFixedRate(itemArrival::newItemArrived, 1, 10, TimeUnit.MILLISECONDS);
-        // acknowledge the items we decided
-        pool.scheduleAtFixedRate(acknowledger::acknowledgeNext, 1, 37, TimeUnit.MILLISECONDS);
-        // emit "timeouts" on anything that lingers too long
-        new Thread(manager).start();
-        latch.await(); // wait for 4 things to timeout
+        try(var pool = Executors.newScheduledThreadPool(2)) {
+            // push new items into the "system"
+            pool.scheduleAtFixedRate(itemArrival::newItemArrived, 1, 10, TimeUnit.MILLISECONDS);
+            // acknowledge the items we decided
+            pool.scheduleAtFixedRate(acknowledger::acknowledgeNext, 1, 37, TimeUnit.MILLISECONDS);
+            // emit "timeouts" on anything that lingers too long
+            new Thread(manager).start();
+            latch.await(); // wait for 4 things to timeout
+        }
     }
 
     private static final class ItemArrival {


### PR DESCRIPTION
- updates to README
- example outputs added to examples
- not handling String or Generic Large stores yet
- run large store tests serially to reduce overall memory usage